### PR TITLE
CI: remove NVIDIA training image from release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,6 @@ jobs:
           grep -Fq "image: \"${image}:ui-${version}\"" "$rendered"
           grep -Fq "image: \"${image}:mlflow-${version}\"" "$rendered"
           grep -Fq "TRAINING_IMAGE: \"${image}:training-cpu-${version}\"" "$rendered"
-          grep -Fq "TRAINING_IMAGE_NVIDIA: \"${image}:training-nvidia-${version}\"" "$rendered"
           grep -Fq "TRAINING_IMAGE_INTEL: \"${image}:training-intel-${version}\"" "$rendered"
           grep -Fq "INFERENCE_IMAGE: \"${image}:inference-${version}\"" "$rendered"
           grep -Fq 'TRAINING_IMAGE_PULL_POLICY: "IfNotPresent"' "$rendered"
@@ -267,7 +266,7 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          for component in api ui mlflow training-cpu training-nvidia training-intel inference
+          for component in api ui mlflow training-cpu training-intel inference
           do
             tag="${IMAGE}:${component}-${VERSION}"
             if docker buildx imagetools inspect "$tag" >/dev/null 2>&1; then
@@ -297,9 +296,6 @@ jobs:
           - component: training-cpu
             context: .
             file: Dockerfile.training.cpu
-          - component: training-nvidia
-            context: .
-            file: Dockerfile.training
           - component: inference
             context: .
             file: Dockerfile.inference
@@ -348,10 +344,6 @@ jobs:
             training-cpu)
               docker run --rm --entrypoint python "$candidate" -c \
                 "import automl_api, catboost, lightgbm, sklearn, xgboost; assert automl_api.__version__ == '${VERSION}'"
-              ;;
-            training-nvidia)
-              docker run --rm --entrypoint python "$candidate" -c \
-                "import automl_api; from cuml import accel; assert automl_api.__version__ == '${VERSION}'"
               ;;
             inference)
               docker run --rm --entrypoint python "$candidate" -c \
@@ -457,7 +449,7 @@ jobs:
         env:
           VERSION: ${{ needs.release-preflight.outputs.version }}
         run: |
-          for component in api ui mlflow training-cpu training-nvidia training-intel inference
+          for component in api ui mlflow training-cpu training-intel inference
           do
             digest="$(cat "$RUNNER_TEMP/digests/$component")"
             docker buildx imagetools create \
@@ -469,7 +461,7 @@ jobs:
         env:
           VERSION: ${{ needs.release-preflight.outputs.version }}
         run: |
-          for component in api ui mlflow training-cpu training-nvidia training-intel inference
+          for component in api ui mlflow training-cpu training-intel inference
           do
             docker buildx imagetools inspect "${IMAGE}:${component}-${VERSION}" >/dev/null
           done

--- a/README.md
+++ b/README.md
@@ -894,7 +894,7 @@ docs/                  Architecture, schema, and decision records
 Create a feature branch, keep changes scoped, add tests for behavioral changes,
 and open a pull request against `dev`. Promote a tested release with a pull
 request from `dev` to protected `main`; use `hotfix/*` only for emergencies.
-Every merge to `main` publishes the seven Docker images to
+Every merge to `main` publishes the six supported Docker images to
 `maponyacharles/sceptreai` using component-and-version tags such as
 `api-0.1.4`. Existing tags are never overwritten, and no `latest`, environment,
 or commit-SHA tags are created. Add a GitHub Actions repository secret named

--- a/infra/helm/sceptre/README.md
+++ b/infra/helm/sceptre/README.md
@@ -47,15 +47,17 @@ provisionable storage before training workloads are considered.
 
 ## Published application images
 
-The chart pulls seven pinned `linux/amd64` images from one public repository:
+The chart pulls six pinned `linux/amd64` images from one public repository:
 
 - `maponyacharles/sceptreai:api-0.1.4`
 - `maponyacharles/sceptreai:ui-0.1.4`
 - `maponyacharles/sceptreai:mlflow-0.1.4`
 - `maponyacharles/sceptreai:training-cpu-0.1.4`
-- `maponyacharles/sceptreai:training-nvidia-0.1.4`
 - `maponyacharles/sceptreai:training-intel-0.1.4`
 - `maponyacharles/sceptreai:inference-0.1.4`
+
+NVIDIA training remains an optional bring-your-own image profile; override
+`training.nvidia.image.repository` and `training.nvidia.image.tag` before enabling it.
 
 No local image build, import, or registry is needed. Override
 `global.imageRegistry`, component repositories, tags, digests, or


### PR DESCRIPTION
Removes the optional NVIDIA/RAPIDS image from the production build, smoke-test, preflight, and publication set after its CuPy/NumPy binary incompatibility failed release run #25. The supported release now publishes six images; NVIDIA remains bring-your-own and disabled by default.